### PR TITLE
Prevent cloudwatch logs link opening in the same tab

### DIFF
--- a/src/main/resources/CodeBuildAction/index.jelly
+++ b/src/main/resources/CodeBuildAction/index.jelly
@@ -99,7 +99,7 @@
             </script>
 
 
-            <h2><a href="${it.logURL}">CloudWatch Logs</a></h2>
+            <h2><a href="${it.logURL}" target="_blank">CloudWatch Logs</a></h2>
             <table class="pane bigtable stripped-odd">
                 <tbody>
                     <tr style="border-top: 0px;" align="left"><th>Container logs</th></tr>


### PR DESCRIPTION
Improves behaviour as this is a different website, it should open in a new tab. 