### PR TITLE
Throw AbortException instead setting the build result on failure

### DIFF
--- a/src/main/java/CodeBuildResult.java
+++ b/src/main/java/CodeBuildResult.java
@@ -1,9 +1,12 @@
 import java.io.Serializable;
 
 public class CodeBuildResult implements Serializable {
-    public static String IN_PROGRESS = "IN_PROGRESS";
-    public static String SUCCESS = "SUCCESS";
-    public static String FAILURE = "FAILURE";
+    public static final long serialVersionUID = 23L;
+
+    public static final String IN_PROGRESS = "IN_PROGRESS";
+    public static final String SUCCESS = "SUCCESS";
+    public static final String FAILURE = "FAILURE";
+    
     private String status = IN_PROGRESS;
     private String errorMessage;
 

--- a/src/main/java/CodeBuildResult.java
+++ b/src/main/java/CodeBuildResult.java
@@ -1,0 +1,26 @@
+import java.io.Serializable;
+
+public class CodeBuildResult implements Serializable {
+    public static String IN_PROGRESS = "IN_PROGRESS";
+    public static String SUCCESS = "SUCCESS";
+    public static String FAILURE = "FAILURE";
+    private String status = IN_PROGRESS;
+    private String errorMessage;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setFailure(String errorMessage){
+        this.status = FAILURE;
+        this.errorMessage = errorMessage;
+    }
+
+    public void setSuccess() {
+        this.status = SUCCESS;
+    }
+}

--- a/src/main/java/CodeBuildStep.java
+++ b/src/main/java/CodeBuildStep.java
@@ -1,4 +1,5 @@
 import com.google.inject.Inject;
+import hudson.AbortException;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -141,6 +142,10 @@ public class CodeBuildStep extends AbstractStepImpl {
                     step.sourceVersion, step.sourceControlType
             );
             builder.perform(run, ws, launcher, listener);
+            CodeBuildResult result = builder.getCodeBuildResult();
+            if(result.getStatus().equals(CodeBuildResult.FAILURE)){
+                throw new AbortException(result.getErrorMessage());
+            }
             return null;
         }
 

--- a/src/test/java/CodeBuilderConfigurationTest.java
+++ b/src/test/java/CodeBuilderConfigurationTest.java
@@ -16,7 +16,10 @@
 
 import com.amazonaws.services.codebuild.model.InvalidInputException;
 import com.amazonaws.services.codebuild.model.StartBuildRequest;
+import hudson.AbortException;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -25,10 +28,15 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
 public class CodeBuilderConfigurationTest extends CodeBuilderTest {
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
 
     @Test
     public void testConfigAllNull() throws IOException, ExecutionException, InterruptedException {
         CodeBuilder test = new CodeBuilder(null, null, null, null, null, null, null, null);
+
+        exception.expect(AbortException.class);
+        exception.expectMessage(CodeBuilder.configuredImproperlyError);
         test.perform(build, ws, launcher, listener);
     }
 
@@ -37,7 +45,11 @@ public class CodeBuilderConfigurationTest extends CodeBuilderTest {
         CodeBuilder test = new CodeBuilder("", "", "", "", "", "", "", "");
 
         test.setAwsClientInitFailureMessage(""); //hide failure from trying to initialize client factory.
+
+        exception.expect(AbortException.class);
+        exception.expectMessage(CodeBuilder.configuredImproperlyError);
         test.perform(build, ws, launcher, listener);
+
         assert(log.toString().contains(CodeBuilder.configuredImproperlyError));
     }
 
@@ -50,6 +62,8 @@ public class CodeBuilderConfigurationTest extends CodeBuilderTest {
 
         CodeBuilder test = createDefaultCodeBuilder();
         fixCodeBuilderFactories(test, mockFactory);
+
+        exception.expect(AbortException.class);
         test.perform(build, ws, launcher, listener);
     }
 
@@ -61,6 +75,8 @@ public class CodeBuilderConfigurationTest extends CodeBuilderTest {
 
         CodeBuilder test = createDefaultCodeBuilder();
         fixCodeBuilderFactories(test, mockFactory);
+
+        exception.expect(AbortException.class);
         test.perform(build, ws, launcher, listener);
     }
 
@@ -72,6 +88,8 @@ public class CodeBuilderConfigurationTest extends CodeBuilderTest {
 
         CodeBuilder test = createDefaultCodeBuilder();
         fixCodeBuilderFactories(test, mockFactory);
+
+        exception.expect(AbortException.class);
         test.perform(build, ws, launcher, listener);
     }
 }

--- a/src/test/java/CodeBuilderConfigurationTest.java
+++ b/src/test/java/CodeBuilderConfigurationTest.java
@@ -16,41 +16,40 @@
 
 import com.amazonaws.services.codebuild.model.InvalidInputException;
 import com.amazonaws.services.codebuild.model.StartBuildRequest;
-import hudson.AbortException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
 public class CodeBuilderConfigurationTest extends CodeBuilderTest {
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
 
     @Test
     public void testConfigAllNull() throws IOException, ExecutionException, InterruptedException {
         CodeBuilder test = new CodeBuilder(null, null, null, null, null, null, null, null);
 
-        exception.expect(AbortException.class);
-        exception.expectMessage(CodeBuilder.configuredImproperlyError);
         test.perform(build, ws, launcher, listener);
+
+        CodeBuildResult result = test.getCodeBuildResult();
+        assertEquals(CodeBuildResult.FAILURE, result.getStatus());
+        assertTrue(result.getErrorMessage().contains(CodeBuilder.configuredImproperlyError));
+
     }
 
     @Test
     public void testConfigAllBlank() throws IOException, ExecutionException, InterruptedException {
         CodeBuilder test = new CodeBuilder("", "", "", "", "", "", "", "");
 
-        test.setAwsClientInitFailureMessage(""); //hide failure from trying to initialize client factory.
-
-        exception.expect(AbortException.class);
-        exception.expectMessage(CodeBuilder.configuredImproperlyError);
         test.perform(build, ws, launcher, listener);
 
         assert(log.toString().contains(CodeBuilder.configuredImproperlyError));
+        CodeBuildResult result = test.getCodeBuildResult();
+        assertEquals(CodeBuildResult.FAILURE, result.getStatus());
+        assertTrue(result.getErrorMessage().contains(CodeBuilder.configuredImproperlyError));
     }
 
     @Test
@@ -63,8 +62,10 @@ public class CodeBuilderConfigurationTest extends CodeBuilderTest {
         CodeBuilder test = createDefaultCodeBuilder();
         fixCodeBuilderFactories(test, mockFactory);
 
-        exception.expect(AbortException.class);
         test.perform(build, ws, launcher, listener);
+
+        CodeBuildResult result = test.getCodeBuildResult();
+        assertEquals(CodeBuildResult.FAILURE, result.getStatus());
     }
 
     @Test
@@ -76,8 +77,10 @@ public class CodeBuilderConfigurationTest extends CodeBuilderTest {
         CodeBuilder test = createDefaultCodeBuilder();
         fixCodeBuilderFactories(test, mockFactory);
 
-        exception.expect(AbortException.class);
         test.perform(build, ws, launcher, listener);
+
+        CodeBuildResult result = test.getCodeBuildResult();
+        assertEquals(CodeBuildResult.FAILURE, result.getStatus());
     }
 
     @Test
@@ -89,7 +92,9 @@ public class CodeBuilderConfigurationTest extends CodeBuilderTest {
         CodeBuilder test = createDefaultCodeBuilder();
         fixCodeBuilderFactories(test, mockFactory);
 
-        exception.expect(AbortException.class);
         test.perform(build, ws, launcher, listener);
+
+        CodeBuildResult result = test.getCodeBuildResult();
+        assertEquals(CodeBuildResult.FAILURE, result.getStatus());
     }
 }

--- a/src/test/java/CodeBuilderEndToEndPerformTest.java
+++ b/src/test/java/CodeBuilderEndToEndPerformTest.java
@@ -18,28 +18,16 @@ import com.amazonaws.services.codebuild.model.BatchGetBuildsRequest;
 import com.amazonaws.services.codebuild.model.BatchGetBuildsResult;
 import com.amazonaws.services.codebuild.model.Build;
 import com.amazonaws.services.codebuild.model.StatusType;
-import hudson.AbortException;
-import hudson.model.Result;
-import junit.framework.AssertionFailedError;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.mockito.ArgumentCaptor;
 
 import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class CodeBuilderEndToEndPerformTest extends CodeBuilderTest {
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
-
     @Test
     public void testBuildSuccess() throws Exception {
         setUpBuildEnvironment();
@@ -49,6 +37,8 @@ public class CodeBuilderEndToEndPerformTest extends CodeBuilderTest {
         test.perform(build, ws, launcher, listener);
 
         assertNull(build.getResult());
+        CodeBuildResult result = test.getCodeBuildResult();
+        assertEquals(CodeBuildResult.SUCCESS, result.getStatus());
     }
 
     @Test
@@ -66,6 +56,8 @@ public class CodeBuilderEndToEndPerformTest extends CodeBuilderTest {
         test.perform(build, ws, launcher, listener);
 
         assertNull(build.getResult());
+        CodeBuildResult result = test.getCodeBuildResult();
+        assertEquals(CodeBuildResult.SUCCESS, result.getStatus());
     }
 
     @Test
@@ -75,8 +67,10 @@ public class CodeBuilderEndToEndPerformTest extends CodeBuilderTest {
         when(mockBuild.getBuildStatus()).thenReturn(StatusType.FAILED.toString().toUpperCase());
         fixCodeBuilderFactories(test, mockFactory);
 
-        exception.expect(AbortException.class);
         test.perform(build, ws, launcher, listener);
+
+        CodeBuildResult result = test.getCodeBuildResult();
+        assertEquals(CodeBuildResult.FAILURE, result.getStatus());
     }
 
     @Test
@@ -91,7 +85,9 @@ public class CodeBuilderEndToEndPerformTest extends CodeBuilderTest {
         CodeBuilder test = createDefaultCodeBuilder();
         fixCodeBuilderFactories(test, mockFactory);
 
-        exception.expect(AbortException.class);
         test.perform(build, ws, launcher, listener);
+
+        CodeBuildResult result = test.getCodeBuildResult();
+        assertEquals(CodeBuildResult.FAILURE, result.getStatus());
     }
 }

--- a/src/test/java/CodeBuilderPerformTest.java
+++ b/src/test/java/CodeBuilderPerformTest.java
@@ -17,12 +17,17 @@
 import com.amazonaws.services.codebuild.model.BatchGetBuildsRequest;
 import com.amazonaws.services.codebuild.model.InvalidInputException;
 import com.amazonaws.services.codebuild.model.StartBuildRequest;
+import hudson.AbortException;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 
 public class CodeBuilderPerformTest extends CodeBuilderTest {
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
 
     @Test
     public void testGetCBClientExcepts() throws Exception {
@@ -31,7 +36,11 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
         String error = "failed to instantiate cb client.";
         doThrow(new InvalidInputException(error)).when(mockFactory).getCodeBuildClient();
         fixCodeBuilderFactories(test, mockFactory);
+
+        exception.expect(AbortException.class);
+        exception.expectMessage(error);
         test.perform(build, ws, launcher, listener);
+
         assert(log.toString().contains(error));
     }
 
@@ -42,7 +51,11 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
         String error = "submit build exception.";
         doThrow(new InvalidInputException(error)).when(mockClient).startBuild(any(StartBuildRequest.class));
         fixCodeBuilderFactories(test, mockFactory);
+
+        exception.expect(AbortException.class);
+        exception.expectMessage(error);
         test.perform(build, ws, launcher, listener);
+
         String s = log.toString();
         assert(log.toString().contains(error));
     }
@@ -54,7 +67,11 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
         doThrow(new InvalidInputException(error)).when(mockClient).batchGetBuilds(any(BatchGetBuildsRequest.class));
         CodeBuilder test = createDefaultCodeBuilder();
         fixCodeBuilderFactories(test, mockFactory);
+
+        exception.expect(AbortException.class);
+        exception.expectMessage(error);
         test.perform(build, ws, launcher, listener);
+
         assert(log.toString().contains(error));
 
     }

--- a/src/test/java/CodeBuilderPerformTest.java
+++ b/src/test/java/CodeBuilderPerformTest.java
@@ -17,17 +17,14 @@
 import com.amazonaws.services.codebuild.model.BatchGetBuildsRequest;
 import com.amazonaws.services.codebuild.model.InvalidInputException;
 import com.amazonaws.services.codebuild.model.StartBuildRequest;
-import hudson.AbortException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 
 public class CodeBuilderPerformTest extends CodeBuilderTest {
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
 
     @Test
     public void testGetCBClientExcepts() throws Exception {
@@ -37,11 +34,12 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
         doThrow(new InvalidInputException(error)).when(mockFactory).getCodeBuildClient();
         fixCodeBuilderFactories(test, mockFactory);
 
-        exception.expect(AbortException.class);
-        exception.expectMessage(error);
         test.perform(build, ws, launcher, listener);
 
         assert(log.toString().contains(error));
+        CodeBuildResult result = test.getCodeBuildResult();
+        assertEquals(CodeBuildResult.FAILURE, result.getStatus());
+        assertTrue(result.getErrorMessage().contains(error));
     }
 
     @Test
@@ -52,12 +50,12 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
         doThrow(new InvalidInputException(error)).when(mockClient).startBuild(any(StartBuildRequest.class));
         fixCodeBuilderFactories(test, mockFactory);
 
-        exception.expect(AbortException.class);
-        exception.expectMessage(error);
         test.perform(build, ws, launcher, listener);
 
-        String s = log.toString();
         assert(log.toString().contains(error));
+        CodeBuildResult result = test.getCodeBuildResult();
+        assertEquals(CodeBuildResult.FAILURE, result.getStatus());
+        assertTrue(result.getErrorMessage().contains(error));
     }
 
     @Test
@@ -68,11 +66,12 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
         CodeBuilder test = createDefaultCodeBuilder();
         fixCodeBuilderFactories(test, mockFactory);
 
-        exception.expect(AbortException.class);
-        exception.expectMessage(error);
         test.perform(build, ws, launcher, listener);
 
         assert(log.toString().contains(error));
+        CodeBuildResult result = test.getCodeBuildResult();
+        assertEquals(CodeBuildResult.FAILURE, result.getStatus());
+        assertTrue(result.getErrorMessage().contains(error));
 
     }
 

--- a/src/test/java/CodeBuilderTest.java
+++ b/src/test/java/CodeBuilderTest.java
@@ -67,7 +67,6 @@ public class CodeBuilderTest {
     //creates a CodeBuilder with mock parameters that reflect a typical use case.
     protected CodeBuilder createDefaultCodeBuilder() {
         CodeBuilder cb = new CodeBuilder("host", "60", "a", "s", "us-east-1", "existingProject", "sourceVersion", SourceControlType.ProjectSource.toString());
-        cb.setAwsClientInitFailureMessage(""); //hide failure from trying to initialize client factory.
             // It will be a mock factory during testing.
         return cb;
 


### PR DESCRIPTION
Today, whenever the aws-codebuild plugin encouters an error, we do `build.setResult("Failure")`. This sets the result on the master build to failure. When used in the context of a pipeline as a step the step does not show as failed (the master build does). It becomes very hard for the user to dig where the real error happened. This problem is exaggerated when there a lot of parallel steps. See https://github.com/awslabs/aws-codebuild-jenkins-plugin/issues/28
