### PR TITLE
Log the logs url

### DIFF
--- a/src/main/java/CodeBuilder.java
+++ b/src/main/java/CodeBuilder.java
@@ -191,7 +191,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
                 if(!haveInitializedAction) {
                     logMonitor = new CloudWatchMonitor(awsClientFactory.getCloudWatchLogsClient());
                     action = new CodeBuildAction(build);
-                    updateDashboard(currentBuild, action, logMonitor);
+                    updateDashboard(currentBuild, action, logMonitor, listener);
 
                     //only need to set these once, the others will need to be updated below as the build progresses.
                     String buildARN = currentBuild.getArn();
@@ -205,7 +205,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
                 }
                 Thread.sleep(5000L);
                 logMonitor.pollForLogs();
-                updateDashboard(currentBuild, action, logMonitor);
+                updateDashboard(currentBuild, action, logMonitor, listener);
 
             } catch(Exception e) {
                 LoggingHelper.log(listener, e.getMessage());
@@ -250,14 +250,18 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
 
     // Performs an update of build data to the codebuild dashboard.
     // @param action: the entity representing the dashboard.
-    private void updateDashboard(Build b, CodeBuildAction action, CloudWatchMonitor logMonitor) {
+    private void updateDashboard(Build b, CodeBuildAction action, CloudWatchMonitor logMonitor, TaskListener listener) {
         if(action != null) {
             action.setCurrentStatus(b.getBuildStatus());
             action.setLogs(logMonitor.getLatestLogs());
             action.setPhases(b.getPhases());
             logMonitor.setLogsLocation(b.getLogs());
             if (logMonitor.getLogsLocation() != null) {
-                action.setLogURL(logMonitor.getLogsLocation().getDeepLink());
+                if(action.getLogURL() == null){
+                    String logUrl = logMonitor.getLogsLocation().getDeepLink();
+                    action.setLogURL(logUrl);
+                    LoggingHelper.log(listener, "Logs url: " + logUrl);
+                }
             }
         }
     }


### PR DESCRIPTION
so that users can easily jump to logs of a particular step. When there are multiple parallel codebuild steps, it is not possible to go to the dashboard for every step. See https://github.com/awslabs/aws-codebuild-jenkins-plugin/issues/27
#### Alternative solution
If we log the cloudwatch logs url for the step, then the user can see the logs for each step in the logs of each step (see screen shot). This solves https://github.com/awslabs/aws-codebuild-jenkins-plugin/issues/27 to a certain extent because, the logs contain the phase information (though in a less nicer form).
So now users have to go through 3 steps (assuming a pipeline build)
1. Figure out which step failed
<img width="1280" alt="screenshot 2017-06-14 12 11 08" src="https://user-images.githubusercontent.com/109035/27118807-a8ce9028-50fa-11e7-88c1-eb5e521b4755.png">

2. Go the logs of that step and click on the actual cloudwatch url
<img width="1280" alt="screenshot 2017-06-14 12 02 26" src="https://user-images.githubusercontent.com/109035/27118559-72862ffe-50f9-11e7-999c-0b94ef77f24b.png">

3. Go the cloudwatch dashboard and see why the build really failed
<img width="1262" alt="screenshot 2017-06-14 12 14 36" src="https://user-images.githubusercontent.com/109035/27118901-1e2684ca-50fb-11e7-9808-ab97b9030349.png">

