### PR TITLE
Add build sepc file option

### DIFF
--- a/src/main/java/CodeBuildStep.java
+++ b/src/main/java/CodeBuildStep.java
@@ -22,6 +22,7 @@ public class CodeBuildStep extends AbstractStepImpl {
     private String projectName;
     private String sourceVersion;
     private String sourceControlType;
+    private String buildSpecFile;
 
     public String getProxyHost() {
         return proxyHost;
@@ -95,6 +96,15 @@ public class CodeBuildStep extends AbstractStepImpl {
         this.sourceControlType = sourceControlType;
     }
 
+    public String getBuildSpecFile() {
+        return buildSpecFile;
+    }
+
+    @DataBoundSetter
+    public void setBuildSpecFile(String buildSpecFile) {
+        this.buildSpecFile = buildSpecFile;
+    }
+
     @Extension
     public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
 
@@ -139,7 +149,7 @@ public class CodeBuildStep extends AbstractStepImpl {
                     step.getAwsAccessKey(), step.getAwsSecretKey(),
                     step.getRegion(),
                     step.getProjectName(),
-                    step.sourceVersion, step.sourceControlType
+                    step.sourceVersion, step.sourceControlType, step.buildSpecFile
             );
             builder.perform(run, ws, launcher, listener);
             CodeBuildResult result = builder.getCodeBuildResult();

--- a/src/main/java/CodeBuilder.java
+++ b/src/main/java/CodeBuilder.java
@@ -51,6 +51,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
     @Getter private final CodeBuildResult codeBuildResult;
     @Getter private String projectName;
     @Getter private String sourceVersion;
+    @Getter private String buildSpecFile;
 
     @Setter private String awsClientInitFailureMessage;
     @Setter private AWSClientFactory awsClientFactory;
@@ -72,7 +73,8 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
 
     @DataBoundConstructor
     public CodeBuilder(String proxyHost, String proxyPort, String awsAccessKey, String awsSecretKey,
-                       String region, String projectName, String sourceVersion, String sourceControlType) {
+                       String region, String projectName, String sourceVersion, String sourceControlType,
+                       String buildSpecFile) {
 
         this.sourceControlType = sourceControlType;
         this.proxyHost = Validation.sanitize(proxyHost);
@@ -82,6 +84,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
         this.region = region;
         this.projectName = projectName;
         this.sourceVersion = Validation.sanitize(sourceVersion);
+        this.buildSpecFile = Validation.sanitize(buildSpecFile);
         this.awsClientInitFailureMessage = "";
         this.codeBuildResult = new CodeBuildResult();
         try {
@@ -168,8 +171,11 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
         }
 
         StartBuildRequest startBuildRequest = new StartBuildRequest()
-                .withProjectName(this.projectName).withSourceVersion(sourceVersion);
-        LoggingHelper.log(listener, "Starting build with projectName " + this.projectName + " and source version " + this.sourceVersion);
+                .withProjectName(this.projectName)
+                .withSourceVersion(this.sourceVersion)
+                .withBuildspecOverride(this.buildSpecFile);
+        LoggingHelper.log(listener, "Starting build with projectName " + this.projectName
+                + " , source version " + this.sourceVersion + " and build spec file " + this.buildSpecFile);
         final StartBuildResult sbResult;
         try {
             sbResult = cbClient.startBuild(startBuildRequest);

--- a/src/main/resources/CodeBuilder/config.jelly
+++ b/src/main/resources/CodeBuilder/config.jelly
@@ -41,5 +41,9 @@
     <f:radioBlock title="Use Jenkins source" name="sourceControlType" help="/plugin/aws-codebuild/help-jenkinsSourceHelp.html"
                   value="jenkins" checked="${instance.sourceControlTypeEquals('jenkins')}" inline="true">
     </f:radioBlock>
+
+    <f:entry title="Build Spec File (optional)" field="buildSpecFile" help="/plugin/aws-codebuild/help-buildSpecFileHelp.html">
+      <f:textbox />
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/webapp/help-buildSpecFileHelp.html
+++ b/src/main/webapp/help-buildSpecFileHelp.html
@@ -1,0 +1,16 @@
+<!--
+  ~     Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~     Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License.
+  ~     A copy of the License is located at
+  ~
+  ~         http://aws.amazon.com/apache2.0/
+  ~
+  ~     or in the "license" file accompanying this file.
+  ~     This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~     See the License for the specific language governing permissions and limitations under the License.
+  -->
+
+<div>
+    The path to the alternate build spec file relative to the value of the built-in environment variable CODEBUILD_SRC_DIR.
+</div>

--- a/src/test/java/CodeBuilderConfigurationTest.java
+++ b/src/test/java/CodeBuilderConfigurationTest.java
@@ -30,7 +30,7 @@ public class CodeBuilderConfigurationTest extends CodeBuilderTest {
 
     @Test
     public void testConfigAllNull() throws IOException, ExecutionException, InterruptedException {
-        CodeBuilder test = new CodeBuilder(null, null, null, null, null, null, null, null);
+        CodeBuilder test = new CodeBuilder(null, null, null, null, null, null, null, null, null);
 
         test.perform(build, ws, launcher, listener);
 
@@ -42,7 +42,7 @@ public class CodeBuilderConfigurationTest extends CodeBuilderTest {
 
     @Test
     public void testConfigAllBlank() throws IOException, ExecutionException, InterruptedException {
-        CodeBuilder test = new CodeBuilder("", "", "", "", "", "", "", "");
+        CodeBuilder test = new CodeBuilder("", "", "", "", "", "", "", "", "");
 
         test.perform(build, ws, launcher, listener);
 

--- a/src/test/java/CodeBuilderTest.java
+++ b/src/test/java/CodeBuilderTest.java
@@ -66,7 +66,7 @@ public class CodeBuilderTest {
 
     //creates a CodeBuilder with mock parameters that reflect a typical use case.
     protected CodeBuilder createDefaultCodeBuilder() {
-        CodeBuilder cb = new CodeBuilder("host", "60", "a", "s", "us-east-1", "existingProject", "sourceVersion", SourceControlType.ProjectSource.toString());
+        CodeBuilder cb = new CodeBuilder("host", "60", "a", "s", "us-east-1", "existingProject", "sourceVersion", SourceControlType.ProjectSource.toString(), "buildspec.yml");
             // It will be a mock factory during testing.
         return cb;
 


### PR DESCRIPTION
Add "Build Spec File" option to project configuration.

The option specifies ``buildspecOverride`` to use alternative build spec file on build.
http://docs.aws.amazon.com/codebuild/latest/userguide/run-build.html

