### PR TITLE
Return Useful build information from CodeBuildStep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,11 @@
             <version>2.5</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>script-security</artifactId>
+            <version>1.29</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>

--- a/src/main/java/CodeBuildException.java
+++ b/src/main/java/CodeBuildException.java
@@ -1,0 +1,14 @@
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+
+public class CodeBuildException extends InterruptedException{
+    private final CodeBuildResult codeBuildResult;
+
+    public CodeBuildException(CodeBuildResult codeBuildResult) {
+        this.codeBuildResult = codeBuildResult;
+    }
+
+    @Whitelisted
+    public CodeBuildResult getCodeBuildResult() {
+        return codeBuildResult;
+    }
+}

--- a/src/main/java/CodeBuildResult.java
+++ b/src/main/java/CodeBuildResult.java
@@ -1,3 +1,5 @@
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+
 import java.io.Serializable;
 
 public class CodeBuildResult implements Serializable {
@@ -9,14 +11,33 @@ public class CodeBuildResult implements Serializable {
     
     private String status = IN_PROGRESS;
     private String errorMessage;
+    private String buildId;
+    private String arn;
+    private String artifactsLocation;
 
+
+    @Whitelisted
     public String getStatus() {
         return status;
     }
 
+    @Whitelisted
     public String getErrorMessage() {
         return errorMessage;
     }
+
+    @Whitelisted
+    public String getBuildId() {
+        return buildId;
+    }
+
+    @Whitelisted
+    public String getArn() {
+        return arn;
+    }
+
+    @Whitelisted
+    public String getArtifactsLocation() { return artifactsLocation; }
 
     public void setFailure(String errorMessage){
         this.status = FAILURE;
@@ -25,5 +46,14 @@ public class CodeBuildResult implements Serializable {
 
     public void setSuccess() {
         this.status = SUCCESS;
+    }
+
+    public void setBuildInformation(String buildId, String arn) {
+        this.buildId = buildId;
+        this.arn = arn;
+    }
+
+    public void setArtifactsLocation(String artifactsLocation) {
+        this.artifactsLocation = artifactsLocation;
     }
 }

--- a/src/main/java/CodeBuildStep.java
+++ b/src/main/java/CodeBuildStep.java
@@ -113,7 +113,7 @@ public class CodeBuildStep extends AbstractStepImpl {
         }
     }
 
-    public static final class CodeBuildExecution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+    public static final class CodeBuildExecution extends AbstractSynchronousNonBlockingStepExecution<CodeBuildResult> {
 
         private static final long serialVersionUID = 1L;
 
@@ -133,7 +133,7 @@ public class CodeBuildStep extends AbstractStepImpl {
         private transient TaskListener listener;
 
         @Override
-        protected Void run() throws Exception {
+        protected CodeBuildResult run() throws Exception {
             CodeBuilder builder = new CodeBuilder(
                     step.getProxyHost(), step.getProxyPort(),
                     step.getAwsAccessKey(), step.getAwsSecretKey(),
@@ -142,11 +142,14 @@ public class CodeBuildStep extends AbstractStepImpl {
                     step.sourceVersion, step.sourceControlType
             );
             builder.perform(run, ws, launcher, listener);
+
             CodeBuildResult result = builder.getCodeBuildResult();
-            if(result.getStatus().equals(CodeBuildResult.FAILURE)){
-                throw new AbortException(result.getErrorMessage());
+
+            if(result.getStatus().equals(CodeBuildResult.FAILURE)) {
+                throw new CodeBuildException(result);
             }
-            return null;
+
+            return result;
         }
 
         private void readObject(java.io.ObjectInputStream stream) throws java.io.IOException, ClassNotFoundException {

--- a/src/main/java/CodeBuilder.java
+++ b/src/main/java/CodeBuilder.java
@@ -18,7 +18,6 @@ import com.amazonaws.services.codebuild.AWSCodeBuildClient;
 import com.amazonaws.services.codebuild.model.*;
 import com.amazonaws.services.codebuild.model.Build;
 import enums.SourceControlType;
-import hudson.AbortException;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -195,7 +194,6 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
                 }
 
                 currentBuild = buildsForId.get(0);
-
                 if(!haveInitializedAction) {
                     logMonitor = new CloudWatchMonitor(awsClientFactory.getCloudWatchLogsClient());
                     action = new CodeBuildAction(build);
@@ -225,13 +223,18 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
             }
         } while(currentBuild.getBuildStatus().equals(StatusType.IN_PROGRESS.toString()));
 
+        this.codeBuildResult.setBuildInformation(currentBuild.getId(), currentBuild.getArn());
+        BuildArtifacts artifacts = currentBuild.getArtifacts();
+
         if(currentBuild.getBuildStatus().equals(StatusType.SUCCEEDED.toString().toUpperCase(Locale.ENGLISH))) {
             action.setJenkinsBuildSucceeds(true);
             this.codeBuildResult.setSuccess();
+            this.codeBuildResult.setArtifactsLocation(artifacts != null ? artifacts.getLocation() : null);
         } else {
             action.setJenkinsBuildSucceeds(false);
             String errorMessage = buildFailedError + " for " + this.projectName + " and source version " + this.sourceVersion;
             LoggingHelper.log(listener, errorMessage);
+            this.codeBuildResult.setArtifactsLocation(artifacts != null ? artifacts.getLocation() : null);
             this.codeBuildResult.setFailure(errorMessage);
         }
         return;

--- a/src/main/java/CodeBuilder.java
+++ b/src/main/java/CodeBuilder.java
@@ -225,16 +225,15 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
 
         this.codeBuildResult.setBuildInformation(currentBuild.getId(), currentBuild.getArn());
         BuildArtifacts artifacts = currentBuild.getArtifacts();
+        this.codeBuildResult.setArtifactsLocation(artifacts != null ? artifacts.getLocation() : null);
 
         if(currentBuild.getBuildStatus().equals(StatusType.SUCCEEDED.toString().toUpperCase(Locale.ENGLISH))) {
             action.setJenkinsBuildSucceeds(true);
             this.codeBuildResult.setSuccess();
-            this.codeBuildResult.setArtifactsLocation(artifacts != null ? artifacts.getLocation() : null);
         } else {
             action.setJenkinsBuildSucceeds(false);
             String errorMessage = buildFailedError + " for " + this.projectName + " and source version " + this.sourceVersion;
             LoggingHelper.log(listener, errorMessage);
-            this.codeBuildResult.setArtifactsLocation(artifacts != null ? artifacts.getLocation() : null);
             this.codeBuildResult.setFailure(errorMessage);
         }
         return;


### PR DESCRIPTION
#### Problem
AWS Codebuild currently supports saving artifacts from a build into an S3 bucket. However, the bucket name is at the project level and every build can potentially overwrite the artifact from a previous build. See https://github.com/awslabs/aws-codebuild-jenkins-plugin/issues/33

#### Solution (works only if you are using the Pipeline plugin with a Jenkinsfile or Pipeline script)
* Use `CODEBUILD_BUILD_ARN` environment variable as a suffix to your artifact files
   For example, if you are building foo.jar then rename it to foo_${CODEBUILD_BUILD_ARN}.jar
* Access the `CodeBuildResult` object from the Pipeline script/Jenkinsfile like the following
```
node('master'){
def result=null    
try{
  result=awsCodeBuild projectName: 'test', awsAccessKey: "foo", awsSecretKey: "bar", region: "us-east-1"
} catch(Exception ex){
    result=ex.getCodeBuildResult()
    throw ex
} finally {
    def artifactUrl = "${result.getArtifactsLocation()}/foo_${result.getArn()}.jar
    println artifactUrl
    // Code to pull the artifact from S3 and archive it
}    
}
```

`This contribution is under the Apache 2.0 license`