### PR TITLE
Switched to using environment variables to resolve parameters.

### DIFF
--- a/src/test/java/CodeBuilderConfigurationTest.java
+++ b/src/test/java/CodeBuilderConfigurationTest.java
@@ -77,7 +77,8 @@ public class CodeBuilderConfigurationTest extends CodeBuilderTest {
     }
 
     @Test
-    public void testConfigAllBlankPipeline() throws IOException, ExecutionException, InterruptedException {
+    public void testConfigAllBlankPipeline() throws Exception {
+        setUpBuildEnvironment();
         CodeBuilder test = new CodeBuilder("", "", "", "", "",
                 "", "", "", "", "", "",
                 "","","","","",     "", "", "", "");

--- a/src/test/java/CodeBuilderPerformTest.java
+++ b/src/test/java/CodeBuilderPerformTest.java
@@ -141,21 +141,11 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     @Test
     public void testBuildParameters() throws Exception {
         setUpBuildEnvironment();
-        List<ParameterValue> params = new ArrayList();
-        Parameter one = new Parameter("foo", "");
-        one.setValue("bar");
-        Parameter two = new Parameter("foo2", "");
-        two.setValue("bar2");
-        Parameter three = new Parameter("foo3", "");
-        three.setValue("bar3");
 
-        params.add(one);
-        params.add(two);
-        params.add(three);
+        envVars.put("foo", "bar");
+        envVars.put("foo2", "bar2");
+        envVars.put("foo3", "bar3");
 
-        ParametersAction mockParameterAction = mock(ParametersAction.class);
-        when(mockParameterAction.getParameters()).thenReturn(params);
-        when(build.getAction(ParametersAction.class)).thenReturn(mockParameterAction);
 
         CodeBuilder cb = new CodeBuilder("keys", "id123","host", "60", "a", "s",
                 "us-east-1", "$foo", "$foo2-$foo3", "", SourceControlType.ProjectSource.toString(),
@@ -164,8 +154,8 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
 
         cb.perform(build, ws, launcher, listener);
 
-        assertEquals(one.getValue(), cb.getParameterized(cb.getProjectName()));
-        assertEquals(two.getValue() + "-" + three.getValue(), cb.getParameterized(cb.getSourceVersion()));
+        assertEquals(envVars.get("foo"), cb.getParameterized(cb.getProjectName()));
+        assertEquals(envVars.get("foo2") + "-" + envVars.get("foo3"), cb.getParameterized(cb.getSourceVersion()));
     }
 
 

--- a/src/test/java/CodeBuilderTest.java
+++ b/src/test/java/CodeBuilderTest.java
@@ -21,6 +21,7 @@ import com.amazonaws.services.codebuild.model.Project;
 import com.amazonaws.services.logs.AWSLogsClient;
 import com.amazonaws.services.s3.AmazonS3Client;
 import enums.ArtifactType;
+import hudson.EnvVars;
 import hudson.FilePath;
 import enums.SourceControlType;
 import hudson.Launcher;
@@ -64,7 +65,8 @@ public class CodeBuilderTest {
     Launcher launcher = mock(Launcher.class);
     TaskListener listener = mock(TaskListener.class);
 
-    ParametersAction mockParameterAction = mock(ParametersAction.class);
+
+    EnvVars envVars = new EnvVars();
 
     //mock console log
     protected ByteArrayOutputStream log;
@@ -109,8 +111,7 @@ public class CodeBuilderTest {
         when(mockClient.batchGetBuilds(any(BatchGetBuildsRequest.class))).thenReturn(mockGetBuildsResult);
         when(mockGetBuildsResult.getBuilds()).thenReturn(Arrays.asList(mockBuild));
         when(build.getFullDisplayName()).thenReturn("job #1234");
-        when(mockParameterAction.getParameters()).thenReturn(new ArrayList());
-        when(build.getAction(ParametersAction.class)).thenReturn(mockParameterAction);
+        when(build.getEnvironment(any(TaskListener.class))).thenReturn(envVars);
     }
 
     @Before


### PR DESCRIPTION
Current implementation is limited to only resolving against build parameters. 
This change allows resolving from all environment variables which include the build parameters. Was unable to get access GIT_COMMIT from another plugin. In addition this allows for $VAR and ${VAR} placeholder formats.

This contribution is under the Apache 2.0 license.