### PR TITLE
Enable buildspec.yml override in configuration

### DIFF
--- a/src/main/java/CodeBuilder.java
+++ b/src/main/java/CodeBuilder.java
@@ -125,7 +125,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
         this.artifactPathOverride = Validation.sanitize(artifactPathOverride);
         this.envVariables = Validation.sanitize(envVariables);
         this.envParameters = Validation.sanitize(envParameters);
-        this.buildSpecFile = buildSpecFile;
+        this.buildSpecFile = Validation.sanitizeYAML(buildSpecFile);
         this.buildTimeoutOverride = Validation.sanitize(buildTimeoutOverride);
         this.codeBuildResult = new CodeBuildResult();
         this.isPipelineBuild = false;

--- a/src/main/java/CodeBuilder.java
+++ b/src/main/java/CodeBuilder.java
@@ -125,7 +125,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
         this.artifactPathOverride = Validation.sanitize(artifactPathOverride);
         this.envVariables = Validation.sanitize(envVariables);
         this.envParameters = Validation.sanitize(envParameters);
-        this.buildSpecFile = Validation.sanitize(buildSpecFile);
+        this.buildSpecFile = buildSpecFile;
         this.buildTimeoutOverride = Validation.sanitize(buildTimeoutOverride);
         this.codeBuildResult = new CodeBuildResult();
         this.isPipelineBuild = false;

--- a/src/main/java/Validation.java
+++ b/src/main/java/Validation.java
@@ -65,6 +65,15 @@ public class Validation {
         }
     }
 
+
+    public static String sanitizeYAML(final String s) {
+        if(s == null) {
+            return "";
+        } else {
+            return s.replace("\t", " ");
+        }
+    }
+
     //// Configuration-checking functions ////
 
     // CodeBuilder: if any of the parameters in CodeBuilder are bad, this will cause the build to end in failure in CodeBuilder.perform()

--- a/src/main/resources/CodeBuilder/config.jelly
+++ b/src/main/resources/CodeBuilder/config.jelly
@@ -107,7 +107,7 @@
     </f:entry>
 
     <f:entry title="Buildspec Override" field="buildSpecFile" help="/plugin/aws-codebuild/help-buildSpecFileHelp.html">
-      <f:textbox />
+      <f:textarea codemirror-mode="yaml" codemirror-config="mode: 'text/x-yaml'" />
     </f:entry>
 
     <f:entry title="Environment Variables Override" field="envVariables" help="/plugin/aws-codebuild/help-envVariablesHelp.html">

--- a/src/main/webapp/help-buildSpecFileHelp.html
+++ b/src/main/webapp/help-buildSpecFileHelp.html
@@ -12,5 +12,5 @@
   -->
 
 <div>
-    Optional parameter. The path to the alternate build spec file relative to the value of the built-in environment variable CODEBUILD_SRC_DIR.
+    Optional parameter. The path to the alternate build spec file relative to the value of the built-in environment variable CODEBUILD_SRC_DIR. Or a valid YAML file.
 </div>


### PR DESCRIPTION
Allow a user to specify the entire contents of the buildspec in job
configuration is well as specifying a file path.  This matches the behavior
supported by the CodeBuild API.