### PR TITLE
Update Jackson version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,17 +245,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.5</version>
+            <version>2.9.8</version>
         </dependency>
                 <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.5</version>
+            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-cbor</artifactId>
-            <version>2.9.5</version>
+            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.ion</groupId>


### PR DESCRIPTION
There was Github security notice that pointed to a security vulnerability
in com.fasterxml.jackson.core:jackson-databind >= 2.9.0, < 2.9.8