### PR TITLE
feat: able to use local cache

### DIFF
--- a/src/main/java/CodeBuildStep.java
+++ b/src/main/java/CodeBuildStep.java
@@ -78,6 +78,7 @@ public class CodeBuildStep extends AbstractStepImpl {
     @Getter private String certificateOverride;
     @Getter private String cacheTypeOverride;
     @Getter private String cacheLocationOverride;
+    @Getter private String cacheModesOverride;
     @Getter private String cloudWatchLogsStatusOverride;
     @Getter private String cloudWatchLogsGroupNameOverride;
     @Getter private String cloudWatchLogsStreamNameOverride;
@@ -261,6 +262,11 @@ public class CodeBuildStep extends AbstractStepImpl {
     @DataBoundSetter
     public void setCacheLocationOverride(String cacheLocationOverride) {
         this.cacheLocationOverride = cacheLocationOverride;
+    }
+
+    @DataBoundSetter
+    public void setCacheModeOverride(String cacheModesOverride) {
+        this.cacheModesOverride = cacheModesOverride;
     }
 
     @DataBoundSetter
@@ -633,7 +639,7 @@ public class CodeBuildStep extends AbstractStepImpl {
                     step.getArtifactPackagingOverride(), step.getArtifactPathOverride(), step.getArtifactEncryptionDisabledOverride(), step.getOverrideArtifactName(),
                     step.getSecondaryArtifactsOverride(), step.getEnvVariables(), step.getEnvParameters(), step.getBuildSpecFile(), step.getBuildTimeoutOverride(),
                     step.getSourceTypeOverride(), step.getSourceLocationOverride(), step.getEnvironmentTypeOverride(),
-                    step.getImageOverride(), step.getComputeTypeOverride(), step.getCacheTypeOverride(), step.getCacheLocationOverride(),
+                    step.getImageOverride(), step.getComputeTypeOverride(), step.getCacheTypeOverride(), step.getCacheLocationOverride(), step.getCacheModesOverride(),
                     step.getCloudWatchLogsStatusOverride(), step.getCloudWatchLogsGroupNameOverride(), step.getCloudWatchLogsStreamNameOverride(),
                     step.getS3LogsStatusOverride(), step.getS3LogsEncryptionDisabledOverride(), step.getS3LogsLocationOverride(), step.getCertificateOverride(), step.getServiceRoleOverride(),
                     step.getInsecureSslOverride(), step.getPrivilegedModeOverride(), step.getCwlStreamingDisabled(), step.getExceptionFailureMode(),

--- a/src/main/java/CodeBuilder.java
+++ b/src/main/java/CodeBuilder.java
@@ -884,7 +884,6 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
             cache.setLocation(getParameterized(cacheLocationOverride));
             overridesSpecified = true;
         }
-
         return overridesSpecified ? cache : null;
     }
 

--- a/src/main/java/CodeBuilder.java
+++ b/src/main/java/CodeBuilder.java
@@ -15,6 +15,7 @@
  */
 
 import com.amazonaws.codebuild.jenkinsplugin.CodeBuildBaseCredentials;
+import com.amazonaws.codebuild.jenkinsplugin.Validation;
 import com.amazonaws.services.codebuild.AWSCodeBuildClient;
 import com.amazonaws.services.codebuild.model.*;
 import com.amazonaws.services.codebuild.model.Build;
@@ -49,6 +50,7 @@ import java.net.URLEncoder;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.amazonaws.codebuild.jenkinsplugin.Validation.*;
 
@@ -89,6 +91,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
     @Getter private String certificateOverride;
     @Getter private String cacheTypeOverride;
     @Getter private String cacheLocationOverride;
+    @Getter private String cacheModesOverride;
     @Getter private String cloudWatchLogsStatusOverride;
     @Getter private String cloudWatchLogsGroupNameOverride;
     @Getter private String cloudWatchLogsStreamNameOverride;
@@ -142,7 +145,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
                        String artifactPackagingOverride, String artifactPathOverride, String artifactEncryptionDisabledOverride, String overrideArtifactName, String secondaryArtifactsOverride,
                        String envVariables, String envParameters, String buildSpecFile, String buildTimeoutOverride, String sourceTypeOverride,
                        String sourceLocationOverride, String environmentTypeOverride, String imageOverride, String computeTypeOverride,
-                       String cacheTypeOverride, String cacheLocationOverride, String cloudWatchLogsStatusOverride, String cloudWatchLogsGroupNameOverride, String cloudWatchLogsStreamNameOverride,
+                       String cacheTypeOverride, String cacheLocationOverride, String cacheModesOverride, String cloudWatchLogsStatusOverride, String cloudWatchLogsGroupNameOverride, String cloudWatchLogsStreamNameOverride,
                        String s3LogsStatusOverride, String s3LogsEncryptionDisabledOverride,  String s3LogsLocationOverride, String certificateOverride, String serviceRoleOverride,
                        String insecureSslOverride, String privilegedModeOverride, String cwlStreamingDisabled, String exceptionFailureMode, String downloadArtifacts, String downloadArtifactsRelativePath) {
 
@@ -180,6 +183,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
         this.computeTypeOverride = sanitize(computeTypeOverride);
         this.cacheTypeOverride = sanitize(cacheTypeOverride);
         this.cacheLocationOverride = sanitize(cacheLocationOverride);
+        this.cacheModesOverride = sanitize(cacheModesOverride);
         this.cloudWatchLogsStatusOverride = sanitize(cloudWatchLogsStatusOverride);
         this.cloudWatchLogsGroupNameOverride = sanitize(cloudWatchLogsGroupNameOverride);
         this.cloudWatchLogsStreamNameOverride = sanitize(cloudWatchLogsStreamNameOverride);
@@ -236,6 +240,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
         computeTypeOverride = sanitize(computeTypeOverride);
         cacheTypeOverride = sanitize(cacheTypeOverride);
         cacheLocationOverride = sanitize(cacheLocationOverride);
+        cacheModesOverride = sanitize(cacheModesOverride);
         cloudWatchLogsStatusOverride = sanitize(cloudWatchLogsStatusOverride);
         cloudWatchLogsGroupNameOverride = sanitize(cloudWatchLogsGroupNameOverride);
         cloudWatchLogsStreamNameOverride = sanitize(cloudWatchLogsStreamNameOverride);
@@ -754,6 +759,9 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
         if(!cacheLocationOverride.isEmpty()) {
             message.append("\n\t> cache location: " + getParameterized(cacheLocationOverride));
         }
+        if(!cacheModesOverride.isEmpty()) {
+            message.append("\n\t> cache modes: " + getParameterized(cacheModesOverride));
+        }
         if(!cloudWatchLogsStatusOverride.isEmpty()) {
             message.append("\n\t> cloudwatch logs status: " + getParameterized(cloudWatchLogsStatusOverride));
         }
@@ -867,11 +875,27 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
             cache.setType(getParameterized(cacheTypeOverride));
             overridesSpecified = true;
         }
+        List<String> cacheModes = listCacheModes(getParameterized(cacheModesOverride));
+        if(!cacheModes.isEmpty() && cache.getType().equals("LOCAL")) {
+            cache.setModes(cacheModes);
+            overridesSpecified = true;
+        }
         if(!getParameterized(cacheLocationOverride).isEmpty()) {
             cache.setLocation(getParameterized(cacheLocationOverride));
             overridesSpecified = true;
         }
+
         return overridesSpecified ? cache : null;
+    }
+
+    // Given a String representing cache modes, returns a list of String
+    // The input string must be in the form [LOCAL_DOCKER_LAYER_CACHE, LOCAL_CUSTOM_CACHE] or else empty list is returned
+    public List<String> listCacheModes(String cacheModes) {
+        if(cacheModes == null || cacheModes.isEmpty()) {
+            return Collections.emptyList();
+        }
+        cacheModes = cacheModes.replaceAll("^.|.$", "");
+        return Arrays.asList(cacheModes.split("\\s*,\\s*"));
     }
 
     private LogsConfig generateStartBuildLogsConfigOverride() {

--- a/src/main/java/CodeBuilderValidation.java
+++ b/src/main/java/CodeBuilderValidation.java
@@ -37,7 +37,8 @@ public class CodeBuilderValidation {
     public static final String invalidSourceTypeError = "Source type override must be one of 'CODECOMMIT', 'S3', 'GITHUB', 'GITHUB_ENTERPRISE', 'BITBUCKET'";
     public static final String invalidComputeTypeError = "Compute type override must be one of 'BUILD_GENERAL1_SMALL', 'BUILD_GENERAL1_MEDIUM', 'BUILD_GENERAL1_LARGE'";
     public static final String invalidEnvironmentTypeError = "Environment type override must be one of 'LINUX_CONTAINER', 'WINDOWS_CONTAINER'";
-    public static final String invalidCacheTypeError = "Cache type override must be one of 'S3', 'NO_CACHE'";
+    public static final String invalidCacheTypeError = "Cache type override must be one of 'S3', 'NO_CACHE', 'LOCAL'";
+    public static final String invalidCacheModesError = "Cache modes override must be one or more from 'LOCAL_SOURCE_CACHE', 'LOCAL_DOCKER_LAYER_CACHE', 'LOCAL_CUSTOM_CACHE'";
     public static final String invalidCloudWatchLogsStatusError = "CloudWatch Logs status override must be one of 'ENABLED', 'DISABLED'";
     public static final String invalidS3LogsStatusError = "S3 logs status override must be one of 'ENABLED', 'DISABLED'";
     public static final String invalidSourceUploaderNullWorkspaceError = "Project workspace is null";
@@ -123,6 +124,17 @@ public class CodeBuilderValidation {
                 CacheType.fromValue(cacheTypeOverride);
             } catch(IllegalArgumentException e) {
                 return invalidCacheTypeError;
+            }
+        }
+
+        String cacheModesOverride = cb.getParameterized(cb.getCacheModesOverride());
+        if (!cacheModesOverride.isEmpty()) {
+            try {
+                for (String mode : cb.listCacheModes(cacheModesOverride)) {
+                    CacheMode.fromValue(mode);
+                }
+            } catch (IllegalArgumentException e) {
+                return invalidCacheModesError;
             }
         }
 

--- a/src/main/resources/CodeBuilder/config.jelly
+++ b/src/main/resources/CodeBuilder/config.jelly
@@ -180,6 +180,10 @@
       <f:textbox />
     </f:entry>
 
+    <f:entry title="Cache Modes Override" field="cacheModesOverride" help="/plugin/aws-codebuild/help-cacheModesOverride.html">
+      <f:textbox />
+    </f:entry>
+
     <f:entry title="CloudWatch Logs Status Override" field="cloudWatchLogsStatusOverride" help="/plugin/aws-codebuild/help-cloudWatchLogsStatusOverride.html">
       <f:select />
     </f:entry>

--- a/src/main/webapp/help-cacheModesOverride.html
+++ b/src/main/webapp/help-cacheModesOverride.html
@@ -1,0 +1,15 @@
+<div>
+
+  Optional build cache modes override.
+
+  <ul>
+
+    <li>If cache mode is set to LOCAL_SOURCE_CACHE, this is mode caches Git metadata for primary and secondary sources.
+
+    <li>If cache mode is set to LOCAL_DOCKER_LAYER_CACHE, this is mode caches existing Docker layers..
+
+    <li>If cache mode is set to LOCAL_CUSTOM_CACHE, this is mode caches directories you specify in the buildspec file.
+
+  </ul>
+
+</div>

--- a/src/main/webapp/help-cacheModesOverride.html
+++ b/src/main/webapp/help-cacheModesOverride.html
@@ -6,7 +6,7 @@
 
     <li>If cache mode is set to LOCAL_SOURCE_CACHE, this is mode caches Git metadata for primary and secondary sources.
 
-    <li>If cache mode is set to LOCAL_DOCKER_LAYER_CACHE, this is mode caches existing Docker layers..
+    <li>If cache mode is set to LOCAL_DOCKER_LAYER_CACHE, this is mode caches existing Docker layers.
 
     <li>If cache mode is set to LOCAL_CUSTOM_CACHE, this is mode caches directories you specify in the buildspec file.
 

--- a/src/main/webapp/help-cacheTypeOverride.html
+++ b/src/main/webapp/help-cacheTypeOverride.html
@@ -19,6 +19,8 @@
         <li>If type is set to NO_CACHE, then the build will not use any cache.
 
         <li>If type is set to S3, then the build will read and write from/to S3.
+
+        <li>If type is set to LOCAL, then the build will stores a cache locally on a build host that is only available to that build host.
     </ul>
 
 </div>

--- a/src/test/java/CodeBuilderEndToEndPerformTest.java
+++ b/src/test/java/CodeBuilderEndToEndPerformTest.java
@@ -196,8 +196,8 @@ public class CodeBuilderEndToEndPerformTest extends CodeBuilderTest {
     public void testBuildFailsWithExceptionFailureMode() throws Exception {
         //exceptionFailureMode should be enabled
         CodeBuilder test = new CodeBuilder("", "", "", "", "", null, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
-                "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
-                "ENABLED", "DISABLED", "");
+                                           "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
+                                           "ENABLED", "DISABLED", "");
 
         exception.expect(AbortException.class);
         exception.expectMessage(CodeBuilder.configuredImproperlyError + "\n\t> " + CodeBuilderValidation.projectRequiredError);

--- a/src/test/java/CodeBuilderPerformTest.java
+++ b/src/test/java/CodeBuilderPerformTest.java
@@ -226,7 +226,7 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
                                            SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
                                            "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
                                            "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
-                                           EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), "LOCAL", "", "[invalidMode, ]",
+                                           EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), "LOCAL", "", "[invalidMode, LOCAL_DOCKER_LAYER_CACHE]",
                                            LogsConfigStatusType.ENABLED.toString(), "group", "stream", LogsConfigStatusType.ENABLED.toString(), "", "location",
                                            "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
@@ -247,7 +247,7 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
                                            SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
                                            "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
                                            "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
-                                           EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "", "",
+                                           EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "", "[LOCAL_DOCKER_LAYER_CACHE]",
                                            "invalidCloudWatchLogsStatus", "group", "stream", LogsConfigStatusType.ENABLED.toString(), "", "location",
                                            "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
@@ -268,7 +268,7 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
                                            SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
                                            "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
                                            "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
-                                           EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "", "",
+                                           EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "", "[LOCAL_CUSTOM_CACHE]",
                                            LogsConfigStatusType.ENABLED.toString(), "group", "stream", "invalidS3LogsStatus", "", "location",
                                            "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
@@ -289,7 +289,7 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
                                            SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
                                            "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
                                            "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", "invalidSourceType", "https://1.0.0.0.86/my_repo",
-                                           EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "", "",
+                                           EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "", "[LOCAL_CUSTOM_CACHE, LOCAL_SOURCE_CACHE]",
                                            LogsConfigStatusType.ENABLED.toString(), "group", "stream", LogsConfigStatusType.ENABLED.toString(), "", "location",
                                            "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);

--- a/src/test/java/CodeBuilderPerformTest.java
+++ b/src/test/java/CodeBuilderPerformTest.java
@@ -51,7 +51,7 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
                                            null, null, null, null, null, null, null, null, null, null, null, null,
                                            null, null, null, null, null, null, null, null, null, null, null, null,
                                            null, null, null, null, null, null, "", null, null, null,
-                                            null, null, null, null, null, null);
+                                           null, null, null, null, null, null, null);
 
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
         test.perform(build, ws, launcher, listener, mockStepContext);
@@ -68,7 +68,7 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     public void testConfigAllBlank() throws Exception {
         CodeBuilder test = new CodeBuilder("", "", "", "", "", null, "", "", "", "", "", "", "", "", "", "", "", "",
                                            "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
-                                           "", "", "", "", "", "", "", "", "", "", "", "", "", "", "");
+                                           "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "");
 
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
         test.perform(build, ws, launcher, listener, mockStepContext);
@@ -84,10 +84,10 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     @Test
     public void testNoProjectName() throws Exception {
         CodeBuilder test = new CodeBuilder("keys", "", "", "", "",
-                null, "", "us-east-1", "", "", "",
-                SourceControlType.ProjectSource.toString(), "", "", "", "", "", "", "",
-                "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
-                "", "", "", "", "", "", "", "", "", "", "", "", "", "", "");
+                                           null, "", "us-east-1", "", "", "",
+                                           SourceControlType.ProjectSource.toString(), "", "", "", "", "", "", "",
+                                           "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
+                                           "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "");
 
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
         test.perform(build, ws, launcher, listener, mockStepContext);
@@ -106,10 +106,10 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     @Test
     public void testNoSourceType() throws Exception {
         CodeBuilder test = new CodeBuilder("keys", "", "", "", "",
-                null, "", "us-east-1", "project", "", "", "",
-                "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
-                "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
-                "", "", "", "", "");
+                                           null, "", "us-east-1", "project", "", "", "",
+                                           "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
+                                           "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
+                                           "", "", "", "", "", "");
 
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
         test.perform(build, ws, launcher, listener, mockStepContext);
@@ -180,13 +180,13 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     @Test
     public void testComputeTypeOverrideException() throws Exception {
         CodeBuilder test = new CodeBuilder("keys", "id123", "host", "60", "a", awsSecretKey,
-                "", "us-east-1", "existingProject", "sourceVersion", "",
-                SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
-                "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
-                "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
-                EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", "invalidComputeType", CacheType.NO_CACHE.toString(), "",
-                LogsConfigStatusType.ENABLED.toString(), "group", "stream", LogsConfigStatusType.ENABLED.toString(), "", "location",
-                "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
+                                           "", "us-east-1", "existingProject", "sourceVersion", "",
+                                           SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
+                                           "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
+                                           "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
+                                           EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", "invalidComputeType", CacheType.NO_CACHE.toString(), "", "",
+                                           LogsConfigStatusType.ENABLED.toString(), "group", "stream", LogsConfigStatusType.ENABLED.toString(), "", "location",
+                                           "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
         test.perform(build, ws, launcher, listener, mockStepContext);
 
@@ -201,13 +201,13 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     @Test
     public void testCacheTypeOverrideException() throws Exception {
         CodeBuilder test = new CodeBuilder("keys", "id123", "host", "60", "a", awsSecretKey,
-                "", "us-east-1", "existingProject", "sourceVersion", "",
-                SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
-                "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
-                "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
-                EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), "invalidCacheType", "",
-                LogsConfigStatusType.ENABLED.toString(), "group", "stream", LogsConfigStatusType.ENABLED.toString(), "",  "location",
-                "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
+                                           "", "us-east-1", "existingProject", "sourceVersion", "",
+                                           SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
+                                           "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
+                                           "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
+                                           EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), "invalidCacheType", "", "",
+                                           LogsConfigStatusType.ENABLED.toString(), "group", "stream", LogsConfigStatusType.ENABLED.toString(), "", "location",
+                                           "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
         test.perform(build, ws, launcher, listener, mockStepContext);
 
@@ -220,15 +220,36 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     }
 
     @Test
+    public void testCacheModesOverrideException() throws Exception {
+        CodeBuilder test = new CodeBuilder("keys", "id123", "host", "60", "a", awsSecretKey,
+                                           "", "us-east-1", "existingProject", "sourceVersion", "",
+                                           SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
+                                           "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
+                                           "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
+                                           EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), "LOCAL", "", "[invalidMode, ]",
+                                           LogsConfigStatusType.ENABLED.toString(), "group", "stream", LogsConfigStatusType.ENABLED.toString(), "", "location",
+                                           "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
+        ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
+        test.perform(build, ws, launcher, listener, mockStepContext);
+
+        verify(build).setResult(savedResult.capture());
+        assertEquals(savedResult.getValue(), Result.FAILURE);
+        assertEquals("Invalid log contents: " + log.toString(), log.toString().contains(CodeBuilderValidation.invalidCacheModesError), true);
+        CodeBuildResult result = test.getCodeBuildResult();
+        assertEquals(CodeBuildResult.FAILURE, result.getStatus());
+        assertTrue(result.getErrorMessage().contains(CodeBuilderValidation.invalidCacheModesError));
+    }
+
+    @Test
     public void testCloudWatchLogsStatusOverrideException() throws Exception {
         CodeBuilder test = new CodeBuilder("keys", "id123", "host", "60", "a", awsSecretKey,
-                "", "us-east-1", "existingProject", "sourceVersion", "",
-                SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
-                "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
-                "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
-                EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "",
-                "invalidCloudWatchLogsStatus", "group", "stream", LogsConfigStatusType.ENABLED.toString(), "",  "location",
-                "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
+                                           "", "us-east-1", "existingProject", "sourceVersion", "",
+                                           SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
+                                           "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
+                                           "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
+                                           EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "", "",
+                                           "invalidCloudWatchLogsStatus", "group", "stream", LogsConfigStatusType.ENABLED.toString(), "", "location",
+                                           "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
         test.perform(build, ws, launcher, listener, mockStepContext);
 
@@ -243,13 +264,13 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     @Test
     public void testS3LogsStatusOverrideException() throws Exception {
         CodeBuilder test = new CodeBuilder("keys", "id123", "host", "60", "a", awsSecretKey,
-                "", "us-east-1", "existingProject", "sourceVersion", "",
-                SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
-                "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
-                "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
-                EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "",
-                LogsConfigStatusType.ENABLED.toString(), "group", "stream", "invalidS3LogsStatus", "", "location",
-                "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
+                                           "", "us-east-1", "existingProject", "sourceVersion", "",
+                                           SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
+                                           "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
+                                           "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
+                                           EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "", "",
+                                           LogsConfigStatusType.ENABLED.toString(), "group", "stream", "invalidS3LogsStatus", "", "location",
+                                           "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
         test.perform(build, ws, launcher, listener, mockStepContext);
 
@@ -264,13 +285,13 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     @Test
     public void testSourceTypeOverrideException() throws Exception {
         CodeBuilder test = new CodeBuilder("keys", "id123", "host", "60", "a", awsSecretKey,
-                "", "us-east-1", "existingProject", "sourceVersion", "",
-                SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
-                "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
-                "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", "invalidSourceType", "https://1.0.0.0.86/my_repo",
-                EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "",
-                LogsConfigStatusType.ENABLED.toString(), "group", "stream", LogsConfigStatusType.ENABLED.toString(), "", "location",
-                "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
+                                           "", "us-east-1", "existingProject", "sourceVersion", "",
+                                           SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
+                                           "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
+                                           "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", "invalidSourceType", "https://1.0.0.0.86/my_repo",
+                                           EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "", "",
+                                           LogsConfigStatusType.ENABLED.toString(), "group", "stream", LogsConfigStatusType.ENABLED.toString(), "", "location",
+                                           "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
         test.perform(build, ws, launcher, listener, mockStepContext);
 
@@ -285,13 +306,13 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     @Test
     public void testEnvironmentTypeOverrideException() throws Exception {
         CodeBuilder test = new CodeBuilder("keys", "id123", "host", "60", "a", awsSecretKey,
-                "", "us-east-1", "existingProject", "sourceVersion", "",
-                SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
-                "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
-                "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
-                "invalidEnvironmentType", "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "",
-                LogsConfigStatusType.ENABLED.toString(), "group", "stream", LogsConfigStatusType.ENABLED.toString(), "",  "location",
-                "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
+                                           "", "us-east-1", "existingProject", "sourceVersion", "",
+                                           SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
+                                           "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
+                                           "[{k, v}]", "[{k, p}]", "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
+                                           "invalidEnvironmentType", "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "", "",
+                                           LogsConfigStatusType.ENABLED.toString(), "group", "stream", LogsConfigStatusType.ENABLED.toString(), "", "location",
+                                           "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
         test.perform(build, ws, launcher, listener, mockStepContext);
 
@@ -310,13 +331,13 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
         envVars.put("foo3", "bar3");
 
         CodeBuilder cb = new CodeBuilder("keys", "id123", "host", "60", "a",
-                awsSecretKey, "", "us-east-1", "$foo", "$foo2-$foo3", "",
-                SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
-                "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
-                "[{k, v}]", "", "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
-                EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "",
-                LogsConfigStatusType.ENABLED.toString(), "group", "stream", LogsConfigStatusType.ENABLED.toString(), "",  "location",
-                "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
+                                         awsSecretKey, "", "us-east-1", "$foo", "$foo2-$foo3", "",
+                                         SourceControlType.ProjectSource.toString(), "", "", GitCloneDepth.One.toString(), BooleanValue.False.toString(),
+                                         "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "", "", BooleanValue.False.toString(), BooleanValue.False.toString(), "",
+                                         "[{k, v}]", "", "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
+                                         EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "", "",
+                                         LogsConfigStatusType.ENABLED.toString(), "group", "stream", LogsConfigStatusType.ENABLED.toString(), "", "location",
+                                         "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
 
         cb.perform(build, ws, launcher, listener, mockStepContext);
 

--- a/src/test/java/CodeBuilderTest.java
+++ b/src/test/java/CodeBuilderTest.java
@@ -39,6 +39,7 @@ import java.io.FileNotFoundException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 
 import static org.mockito.Matchers.any;
@@ -85,13 +86,13 @@ public class CodeBuilderTest {
     //creates a CodeBuilder with mock parameters that reflect a typical use case.
     protected CodeBuilder createDefaultCodeBuilder() {
         CodeBuilder cb = new CodeBuilder("keys", "id123", "host", "60", "a", awsSecretKey, "",
-                "us-east-1", "existingProject", "sourceVersion", "", SourceControlType.ProjectSource.toString(), "", "",
-                GitCloneDepth.One.toString(), BooleanValue.False.toString(), "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "",
-                "", BooleanValue.False.toString(), BooleanValue.False.toString(), "", "[{k, v}]", "[{k, p}]",
-                "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
-                EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "",
-                LogsConfigStatusType.ENABLED.toString(), "group", "stream", LogsConfigStatusType.ENABLED.toString(), "", "location",
-                "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
+                                         "us-east-1", "existingProject", "sourceVersion", "", SourceControlType.ProjectSource.toString(), "", "",
+                                         GitCloneDepth.One.toString(), BooleanValue.False.toString(), "", "", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "",
+                                         "", BooleanValue.False.toString(), BooleanValue.False.toString(), "", "[{k, v}]", "[{k, p}]",
+                                         "buildspec.yml", "5", SourceType.GITHUB_ENTERPRISE.toString(), "https://1.0.0.0.86/my_repo",
+                                         EnvironmentType.LINUX_CONTAINER.toString(), "aws/codebuild/openjdk-8", ComputeType.BUILD_GENERAL1_SMALL.toString(), CacheType.NO_CACHE.toString(), "", "",
+                                         LogsConfigStatusType.ENABLED.toString(), "group", "stream", LogsConfigStatusType.ENABLED.toString(), "", "location",
+                                         "arn:aws:s3:::my_bucket/certificate.pem", "my_service_role", BooleanValue.False.toString(), BooleanValue.False.toString(), BooleanValue.False.toString(), "", "DISABLED", "");
 
             // It will be a mock factory during testing.
         return cb;


### PR DESCRIPTION
### *problem*

AWS CodeBuild can use local cache feature, but this plugin can not use it.

### *Description of changes:*

By specifying `cacheModesOverride: [LOCAL_SOURCE_CACHE, LOCAL_DOCKER_LAYER_CACHE, LOCAL_CUSTOM_CACHE]` , we can use local cache.

please review!

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
