### PR TITLE
Preserve file permissions and support include / exclude filters for "Use Jenkins source"

### DIFF
--- a/src/main/java/CodeBuildStep.java
+++ b/src/main/java/CodeBuildStep.java
@@ -55,6 +55,8 @@ public class CodeBuildStep extends AbstractStepImpl {
     @Getter private String sourceControlType;
     @Getter private String localSourcePath;
     @Getter private String workspaceSubdir;
+    @DataBoundSetter public String workspaceIncludes;
+    @DataBoundSetter public String workspaceExcludes;
     @Getter private String sourceVersion;
     @Getter private String sseAlgorithm;
     @Getter private String gitCloneDepthOverride;
@@ -645,6 +647,8 @@ public class CodeBuildStep extends AbstractStepImpl {
                     step.getInsecureSslOverride(), step.getPrivilegedModeOverride(), step.getCwlStreamingDisabled(), step.getExceptionFailureMode(),
                     step.getDownloadArtifacts(), step.getDownloadArtifactsRelativePath()
             ).readResolve();
+            builder.workspaceIncludes = step.workspaceIncludes;
+            builder.workspaceExcludes = step.workspaceExcludes;
 
             try {
                 builder.perform(run, ws, launcher, listener, getContext());

--- a/src/main/java/CodeBuilder.java
+++ b/src/main/java/CodeBuilder.java
@@ -39,6 +39,7 @@ import lombok.Setter;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -68,6 +69,8 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
     @Getter private String sourceControlType;
     @Getter private String localSourcePath;
     @Getter private String workspaceSubdir;
+    @DataBoundSetter public String workspaceIncludes;
+    @DataBoundSetter public String workspaceExcludes;
     @Getter private String sourceVersion;
     @Getter private String sseAlgorithm;
     @Getter private String gitCloneDepthOverride;
@@ -419,7 +422,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
                 return;
             }
 
-            S3DataManager s3DataManager = new S3DataManager(awsClientFactory.getS3Client(), sourceS3Bucket, sourceS3Key, getParameterized(sseAlgorithm), getParameterized(localSourcePath), getParameterized(workspaceSubdir));
+            S3DataManager s3DataManager = new S3DataManager(awsClientFactory.getS3Client(), sourceS3Bucket, sourceS3Key, getParameterized(sseAlgorithm), getParameterized(localSourcePath), getParameterized(workspaceSubdir), getParameterized(workspaceIncludes), getParameterized(workspaceExcludes));
             String uploadedSourceVersion = "";
 
             try {

--- a/src/main/java/S3DataManager.java
+++ b/src/main/java/S3DataManager.java
@@ -42,6 +42,12 @@ public class S3DataManager {
     private final String sseAlgorithm;
     private final String localSourcePath;
     private final String workspaceSubdir;
+    private final String workspaceIncludes;
+    private final String workspaceExcludes;
+
+    public S3DataManager(AmazonS3Client s3Client, String s3InputBucket, String s3InputKey, String sseAlgorithm, String localSourcePath, String workspaceSubdir) {
+        this(s3Client, s3InputBucket, s3InputKey, sseAlgorithm, localSourcePath, workspaceSubdir, null, null);
+    }
 
     // if localSourcePath is empty, clones, zips, and uploads the given workspace. Otherwise, uploads the file referred to by localSourcePath.
     // The upload bucket used is this.s3InputBucket and the name of the zip file is this.s3InputKey.
@@ -66,7 +72,7 @@ public class S3DataManager {
             LoggingHelper.log(listener, "Zipping directory to upload to S3: " + sourcePath);
 
             localFile = new FilePath(workspace, getTempFilePath(sourcePath));
-            zipFileMD5 = localFile.act(new ZipSourceCallable(workspace));
+            zipFileMD5 = localFile.act(new ZipSourceCallable(workspace, workspaceIncludes, workspaceExcludes));
         }
 
         // Add MD5 checksum as S3 Object metadata

--- a/src/main/resources/CodeBuilder/config.jelly
+++ b/src/main/resources/CodeBuilder/config.jelly
@@ -97,6 +97,14 @@
           <f:textbox />
         </f:entry>
 
+        <f:entry title="Inclusion pattern (optional)" field="workspaceIncludes" help="/plugin/aws-codebuild/help-workspaceIncludes.html">
+          <f:textbox />
+        </f:entry>
+
+        <f:entry title="Exclusion pattern (optional)" field="workspaceExcludes" help="/plugin/aws-codebuild/help-workspaceExcludes.html">
+          <f:textbox />
+        </f:entry>
+
     </f:radioBlock>
 
   </f:section>

--- a/src/main/webapp/help-workspaceExcludes.html
+++ b/src/main/webapp/help-workspaceExcludes.html
@@ -1,0 +1,16 @@
+<!--
+  ~     Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~     Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License.
+  ~     A copy of the License is located at
+  ~
+  ~         http://aws.amazon.com/apache2.0/
+  ~
+  ~     or in the "license" file accompanying this file.
+  ~     This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~     See the License for the specific language governing permissions and limitations under the License.
+  -->
+<div>
+    <a href="https://ant.apache.org/manual/Types/fileset.html">Ant fileset patterns</a> to specify files not to be zipped even if files match "Inclusion pattern"(workspaceIncludes).
+    Multiple patterns can be specified separating with commas(,).
+</div>

--- a/src/main/webapp/help-workspaceIncludes.html
+++ b/src/main/webapp/help-workspaceIncludes.html
@@ -1,0 +1,27 @@
+<!--
+  ~     Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~     Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License.
+  ~     A copy of the License is located at
+  ~
+  ~         http://aws.amazon.com/apache2.0/
+  ~
+  ~     or in the "license" file accompanying this file.
+  ~     This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~     See the License for the specific language governing permissions and limitations under the License.
+  -->
+<div>
+    <p>
+    <a href="https://ant.apache.org/manual/Types/fileset.html">Ant fileset patterns</a> to specify files to be zipped.
+    Multiple patterns can be specified separating with commas(,).
+    Leaving blank results all files will be zipped.
+    </p>
+    <p>
+    Some examples:
+    <ul>
+        <li><code>**/*.java</code>: All files with '.java' extension. This includes files in subdirectories.</li>
+        <li><code>*.sh</code>: Files with '.sh' extension in the root directory. This doesn't include files in subdirectories.</li>
+        <li><code>subdir/</code>: All files in the 'subdir' directory.</li>
+    </ul>
+    </p>
+</div>

--- a/src/test/java/CodeBuilderPerformTest.java
+++ b/src/test/java/CodeBuilderPerformTest.java
@@ -52,6 +52,8 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
                                            null, null, null, null, null, null, null, null, null, null, null, null,
                                            null, null, null, null, null, null, "", null, null, null,
                                            null, null, null, null, null, null, null);
+        test.workspaceIncludes = null;
+        test.workspaceExcludes = null;
 
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
         test.perform(build, ws, launcher, listener, mockStepContext);
@@ -69,6 +71,8 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
         CodeBuilder test = new CodeBuilder("", "", "", "", "", null, "", "", "", "", "", "", "", "", "", "", "", "",
                                            "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
                                            "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "");
+        test.workspaceIncludes = "";
+        test.workspaceExcludes = "";
 
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
         test.perform(build, ws, launcher, listener, mockStepContext);

--- a/src/test/java/CodeBuilderTest.java
+++ b/src/test/java/CodeBuilderTest.java
@@ -47,6 +47,9 @@ import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * This is a base class for other test classes. Provides no tests.
+ */
 public class CodeBuilderTest {
 
     AWSClientFactory mockFactory = mock(AWSClientFactory.class);

--- a/src/test/java/S3DataManagerTest.java
+++ b/src/test/java/S3DataManagerTest.java
@@ -582,6 +582,29 @@ public class S3DataManagerTest {
     }
 
     @Test
+    public void testZipSourceIncludesExcludes() throws Exception {
+        File dir = tempFolder.newFolder();
+        FileUtils.write(new File(dir, "test1.txt"), "This will be included");
+        FileUtils.write(new File(dir, "test2.sh"), "This won't be included");
+        FileUtils.write(new File(dir, "test3.txt"), "This will be excluded");
+        FileUtils.write(new File(dir, "test4.txt"), "This will be included");
+
+        File zipFile = tempFolder.newFile("source.zip");
+        FileOutputStream out = new FileOutputStream(zipFile);
+        FilePath workspace = new FilePath(dir);
+        new ZipSourceCallable(workspace, "*.txt", "test3.txt").zipSourceWithArchiver(out);
+        out.close();
+
+        assertTrue(zipFile.exists());
+
+        File unzipFolder = tempFolder.newFolder();
+        new FilePath(zipFile).unzip(new FilePath(unzipFolder));
+        String[] files = unzipFolder.list();
+        Arrays.sort(files);
+        assertEquals(new String[]{"test1.txt", "test4.txt"}, files);
+    }
+
+    @Test
     public void testTrimPrefixBaseWithTrailingSlash() {
         String prefixWithSlash = FilenameUtils.separatorsToSystem("/tmp/dir/");  // "/tmp/dir/" in Linux, "\tmp\dir\" in Windows.
         String path = FilenameUtils.separatorsToSystem("/tmp/dir/folder/file.txt");

--- a/src/test/java/S3DataManagerTest.java
+++ b/src/test/java/S3DataManagerTest.java
@@ -56,7 +56,6 @@ public class S3DataManagerTest {
     private AmazonS3Client s3Client = mock(AmazonS3Client.class);
     private static final String mockWorkspaceDir = "/tmp/jenkins/workspace/proj";
     private FilePath testWorkSpace = new FilePath(new File(mockWorkspaceDir));
-    private FilePath testZipSourceWorkspace = new FilePath(new File("/"));
     Map<String, String> s3ARNs = new HashMap<>();
     private String s3InputBucketName = "Inputbucket";
     private String s3InputKeyName = "InputKey";
@@ -236,8 +235,8 @@ public class S3DataManagerTest {
 
     @Test
     public void testZipSourceEmptyDir() throws Exception {
-        ZipOutputStream out = new ZipOutputStream(new FileOutputStream("/tmp/source.zip"));
-        ZipSourceCallable.zipSource(testZipSourceWorkspace, "/tmp/source/", out, "/tmp/source/");
+        FileOutputStream out = new FileOutputStream("/tmp/source.zip");
+        new ZipSourceCallable(new FilePath(new File("/tmp/source/"))).zipSourceWithArchiver(out);
         out.close();
 
         File zip = new File("/tmp/source.zip");
@@ -256,8 +255,8 @@ public class S3DataManagerTest {
         String buildSpecContents = "yo\n";
         FileUtils.write(buildSpec, buildSpecContents);
 
-        ZipOutputStream out = new ZipOutputStream(new FileOutputStream("/tmp/source.zip"));
-        ZipSourceCallable.zipSource(testZipSourceWorkspace, "/tmp/source/", out, "/tmp/source/");
+        FileOutputStream out = new FileOutputStream("/tmp/source.zip");
+        new ZipSourceCallable(new FilePath(new File("/tmp/source/"))).zipSourceWithArchiver(out);
         out.close();
 
         File zip = new File("/tmp/source.zip");
@@ -282,8 +281,8 @@ public class S3DataManagerTest {
         File sourceDir = new File("/tmp/source/src");
         sourceDir.mkdir();
 
-        ZipOutputStream out = new ZipOutputStream(new FileOutputStream("/tmp/source.zip"));
-        ZipSourceCallable.zipSource(testZipSourceWorkspace, "/tmp/source/", out, "/tmp/source/");
+        FileOutputStream out = new FileOutputStream("/tmp/source.zip");
+        new ZipSourceCallable(new FilePath(new File("/tmp/source/"))).zipSourceWithArchiver(out);
         out.close();
 
         File zip = new File("/tmp/source.zip");
@@ -316,8 +315,8 @@ public class S3DataManagerTest {
         String srcFileContents = "int i = 1;";
         FileUtils.write(srcFile, srcFileContents);
 
-        ZipOutputStream out = new ZipOutputStream(new FileOutputStream("/tmp/source.zip"));
-        ZipSourceCallable.zipSource(testZipSourceWorkspace, "/tmp/source/", out, "/tmp/source/");
+        FileOutputStream out = new FileOutputStream("/tmp/source.zip");
+        new ZipSourceCallable(new FilePath(new File("/tmp/source/"))).zipSourceWithArchiver(out);
         out.close();
 
         File zip = new File("/tmp/source.zip");
@@ -367,8 +366,8 @@ public class S3DataManagerTest {
         FileUtils.write(srcFile, srcFileContents);
         FileUtils.write(srcFile2, srcFile2Contents);
 
-        ZipOutputStream out = new ZipOutputStream(new FileOutputStream("/tmp/source.zip"));
-        ZipSourceCallable.zipSource(testZipSourceWorkspace, "/tmp/source/", out, "/tmp/source/");
+        FileOutputStream out = new FileOutputStream("/tmp/source.zip");
+        new ZipSourceCallable(new FilePath(new File("/tmp/source/"))).zipSourceWithArchiver(out);
         out.close();
 
         File zip = new File("/tmp/source.zip");
@@ -430,8 +429,8 @@ public class S3DataManagerTest {
         FileUtils.write(srcFile, srcFileContents);
         FileUtils.write(srcFile2, srcFile2Contents.toString());
 
-        ZipOutputStream out = new ZipOutputStream(new FileOutputStream("/tmp/source.zip"));
-        ZipSourceCallable.zipSource(testZipSourceWorkspace, "/tmp/source/", out, "/tmp/source/");
+        FileOutputStream out = new FileOutputStream("/tmp/source.zip");
+        new ZipSourceCallable(new FilePath(new File("/tmp/source/"))).zipSourceWithArchiver(out);
         out.close();
 
         File zip = new File("/tmp/source.zip");
@@ -489,8 +488,8 @@ public class S3DataManagerTest {
         FileUtils.write(file4, nestedFile4Contents);
         FileUtils.write(file5, nestedFile5Contents);
 
-        ZipOutputStream out = new ZipOutputStream(new FileOutputStream("/tmp/source.zip"));
-        ZipSourceCallable.zipSource(testZipSourceWorkspace, "/tmp/source/", out, "/tmp/source/");
+        FileOutputStream out = new FileOutputStream("/tmp/source.zip");
+        new ZipSourceCallable(new FilePath(new File("/tmp/source/"))).zipSourceWithArchiver(out);
         out.close();
 
         File zip = new File("/tmp/source.zip");
@@ -534,8 +533,8 @@ public class S3DataManagerTest {
 
         FileUtils.write(buildSpec, contents.toString());
 
-        ZipOutputStream out = new ZipOutputStream(new FileOutputStream("/tmp/source.zip"));
-        ZipSourceCallable.zipSource(testZipSourceWorkspace, "/tmp/source/", out, "/tmp/source/");
+        FileOutputStream out = new FileOutputStream("/tmp/source.zip");
+        new ZipSourceCallable(new FilePath(new File("/tmp/source/"))).zipSourceWithArchiver(out);
         out.close();
 
         File zip = new File("/tmp/source.zip");
@@ -565,9 +564,9 @@ public class S3DataManagerTest {
         new FilePath(scriptFile).chmod(0755);
 
         File zipFile = tempFolder.newFile("source.zip");
-        ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zipFile));
+        FileOutputStream out = new FileOutputStream(zipFile);
         FilePath workspace = new FilePath(dir);
-        ZipSourceCallable.zipSource(workspace, workspace.getRemote(), out, workspace.getRemote());
+        new ZipSourceCallable(workspace).zipSourceWithArchiver(out);
         out.close();
 
         assertTrue(zipFile.exists());


### PR DESCRIPTION
*Issue #, if available:*

#125, #126

*Description of changes:*

Improvements for "Use Jenkins source"

* Preserve file permissions, especially execution bits. This makes it easy to run jobs using script files on CodeBuild.
    * Used [ArchiverFactory](https://javadoc.jenkins.io/hudson/util/io/ArchiverFactory.html) Jenkins core provides as JDK's implementation doesn't handle file permissions.
* Support include / exclude filters. This allows exclude files like '.git/**' from the zip source.
    * Used [Apache Ant directory scanner](https://javadoc.jenkins.io/hudson/Util.html#createFileSet-java.io.File-java.lang.String-java.lang.String-).
    * It requires users to write ant file patterns but I believe it's not so difficult for Jenkins users as ant file patters are often used in Jenkins plugins.

`mvn install` has passed in my environment (maven:3.8.1-jdk-8 docker container).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
