### PR TITLE
Let aws-sdk retry upload especially when conflict with parallel uploads

### DIFF
--- a/src/main/java/LoggingHelper.java
+++ b/src/main/java/LoggingHelper.java
@@ -36,4 +36,13 @@ public class LoggingHelper {
             listener.getLogger().println(completeMessage);
         }
     }
+
+    public static void logError(final TaskListener listener, String message, Throwable t) {
+        log(listener, message);
+        if(listener == null) {
+            t.printStackTrace(System.out);
+        } else {
+            t.printStackTrace(listener.getLogger());
+        }
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

#129

*Description of changes:*

Parallel execution of `awsCodeBuild` results fillowing error:
> [AWS CodeBuild Plugin] Unexpected exception upon uploading source zip to S3: The request to the service failed with a retryable reason, but resetting the request input stream has failed. See exception.getExtraInfo or debug-level logging for the original failure that caused this retry.;  If the request involves an input stream, the maximum stream buffer size can be configured via request.getRequestClientOptions().setReadLimit(int)

This means aws-sdk tries to retry upload using `InputStream#reset` ( https://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html#reset-- ) but it failed.
Actually, I'm not so sure why `reset()` it fails but we can easily retry that re-opening the target file.
I introduced `ResetableFilePathInputStream` which re-opens the file if `reset()` is called.

This contribution is under the Apache 2.0 license.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
